### PR TITLE
update describe() signature for compatibility with servox changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM opsani/servox:edge
+FROM opsani/servox:0.10.7
+# note: keep the servox version equal to the one in pyproject.toml
 
 COPY . /servo/servo_appdynamics
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opsani/servox:0.10.7
+FROM opsani/servox:v0.10.7
 # note: keep the servox version equal to the one in pyproject.toml
 
 COPY . /servo/servo_appdynamics

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM opsani/servox:v0.10.7
 # note: keep the servox version equal to the one in pyproject.toml
 
+RUN pip install poetry==1.1.*
+
 COPY . /servo/servo_appdynamics
 
-RUN poetry add --lock /servo/servo_appdynamics
-RUN poetry install --no-interaction
+RUN poetry add --lock /servo/servo_appdynamics \
+  && poetry install \
+  $(if [ "$SERVO_ENV" = 'production' ]; then echo '--no-dev'; fi) \
+  --no-interaction \
+  && if [ "$SERVO_ENV" = 'production' ]; then rm -rf "$POETRY_CACHE_DIR"; fi

--- a/poetry.lock
+++ b/poetry.lock
@@ -480,7 +480,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "servox"
-version = "0.10.6"
+version = "0.10.7"
 description = "Opsani Servo: The Next Generation"
 category = "main"
 optional = false
@@ -501,7 +501,7 @@ pyaml = ">=20.4.0,<21.0.0"
 pydantic = ">=1.8.1,<2.0.0"
 pyfiglet = ">=0.8.post1,<0.9"
 pygments = ">=2.6.1,<3.0.0"
-python-dotenv = ">=0.15,<0.18"
+python-dotenv = ">=0.15,<0.20"
 pytz = ">=2021.1,<2022.0"
 semver = ">=2.10.1,<3.0.0"
 statesman = ">=1.0.0,<2.0.0"
@@ -509,7 +509,7 @@ tabulate = ">=0.8.7,<0.9.0"
 timeago = ">=1.0.14,<2.0.0"
 toml = ">=0.10.2,<0.11.0"
 typer = ">=0.3.0,<0.4.0"
-uvloop = ">=0.15.2,<0.16.0"
+uvloop = ">=0.16.0,<0.17.0"
 
 [[package]]
 name = "six"
@@ -605,16 +605,16 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "uvloop"
-version = "0.15.2"
+version = "0.16.0"
 description = "Fast implementation of asyncio event loop on top of libuv"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-dev = ["Cython (>=0.29.20,<0.30.0)", "pytest (>=3.6.0)", "Sphinx (>=1.7.3,<1.8.0)", "sphinxcontrib-asyncio (>=0.2.0,<0.3.0)", "sphinx-rtd-theme (>=0.2.4,<0.3.0)", "aiohttp", "flake8 (>=3.8.4,<3.9.0)", "psutil", "pycodestyle (>=2.6.0,<2.7.0)", "pyOpenSSL (>=19.0.0,<19.1.0)", "mypy (>=0.800)"]
-docs = ["Sphinx (>=1.7.3,<1.8.0)", "sphinxcontrib-asyncio (>=0.2.0,<0.3.0)", "sphinx-rtd-theme (>=0.2.4,<0.3.0)"]
-test = ["aiohttp", "flake8 (>=3.8.4,<3.9.0)", "psutil", "pycodestyle (>=2.6.0,<2.7.0)", "pyOpenSSL (>=19.0.0,<19.1.0)", "mypy (>=0.800)"]
+dev = ["Cython (>=0.29.24,<0.30.0)", "pytest (>=3.6.0)", "Sphinx (>=4.1.2,<4.2.0)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "aiohttp", "flake8 (>=3.9.2,<3.10.0)", "psutil", "pycodestyle (>=2.7.0,<2.8.0)", "pyOpenSSL (>=19.0.0,<19.1.0)", "mypy (>=0.800)"]
+docs = ["Sphinx (>=4.1.2,<4.2.0)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)"]
+test = ["aiohttp", "flake8 (>=3.9.2,<3.10.0)", "psutil", "pycodestyle (>=2.7.0,<2.8.0)", "pyOpenSSL (>=19.0.0,<19.1.0)", "mypy (>=0.800)"]
 
 [[package]]
 name = "win32-setctime"
@@ -642,7 +642,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "a50d84ba044b2a661ee6847a27d1b107aea0112588dda37151a4e1642860143d"
+content-hash = "946b7068626139695c4b0a21c881dc00da5bf178a834c39b501d220ec9c13f66"
 
 [metadata.files]
 aiohttp = [
@@ -955,8 +955,8 @@ semver = [
     {file = "semver-2.13.0.tar.gz", hash = "sha256:fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c980ff7f75e3f"},
 ]
 servox = [
-    {file = "servox-0.10.6-py3-none-any.whl", hash = "sha256:0c7ea83937123fbe6529f00e1b2db7394846bfb51614c7c81201a69eaddc1757"},
-    {file = "servox-0.10.6.tar.gz", hash = "sha256:d71cdcb6510579495e2b79060c66c2378eb368fb04f0bd78674a9d6e6458a759"},
+    {file = "servox-0.10.7-py3-none-any.whl", hash = "sha256:92626b87ffd4e69aca3e89bdc0fc13831f2cd75da9b8062bfaf05dbd75353ab6"},
+    {file = "servox-0.10.7.tar.gz", hash = "sha256:014c9fd315365c02a5ba130d90abc5157a72a506e3c47ffaaebd4e77c10e0833"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
@@ -995,16 +995,22 @@ urllib3 = [
     {file = "urllib3-1.26.3.tar.gz", hash = "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"},
 ]
 uvloop = [
-    {file = "uvloop-0.15.2-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:19fa1d56c91341318ac5d417e7b61c56e9a41183946cc70c411341173de02c69"},
-    {file = "uvloop-0.15.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:e5e5f855c9bf483ee6cd1eb9a179b740de80cb0ae2988e3fa22309b78e2ea0e7"},
-    {file = "uvloop-0.15.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:42eda9f525a208fbc4f7cecd00fa15c57cc57646c76632b3ba2fe005004f051d"},
-    {file = "uvloop-0.15.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:90e56f17755e41b425ad19a08c41dc358fa7bf1226c0f8e54d4d02d556f7af7c"},
-    {file = "uvloop-0.15.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:7ae39b11a5f4cec1432d706c21ecc62f9e04d116883178b09671aa29c46f7a47"},
-    {file = "uvloop-0.15.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:b45218c99795803fb8bdbc9435ff7f54e3a591b44cd4c121b02fa83affb61c7c"},
-    {file = "uvloop-0.15.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:114543c84e95df1b4ff546e6e3a27521580466a30127f12172a3278172ad68bc"},
-    {file = "uvloop-0.15.2-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:44cac8575bf168601424302045234d74e3561fbdbac39b2b54cc1d1d00b70760"},
-    {file = "uvloop-0.15.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:6de130d0cb78985a5d080e323b86c5ecaf3af82f4890492c05981707852f983c"},
-    {file = "uvloop-0.15.2.tar.gz", hash = "sha256:2bb0624a8a70834e54dde8feed62ed63b50bad7a1265c40d6403a2ac447bce01"},
+    {file = "uvloop-0.16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6224f1401025b748ffecb7a6e2652b17768f30b1a6a3f7b44660e5b5b690b12d"},
+    {file = "uvloop-0.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:30ba9dcbd0965f5c812b7c2112a1ddf60cf904c1c160f398e7eed3a6b82dcd9c"},
+    {file = "uvloop-0.16.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bd53f7f5db562f37cd64a3af5012df8cac2c464c97e732ed556800129505bd64"},
+    {file = "uvloop-0.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:772206116b9b57cd625c8a88f2413df2fcfd0b496eb188b82a43bed7af2c2ec9"},
+    {file = "uvloop-0.16.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b572256409f194521a9895aef274cea88731d14732343da3ecdb175228881638"},
+    {file = "uvloop-0.16.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:04ff57aa137230d8cc968f03481176041ae789308b4d5079118331ab01112450"},
+    {file = "uvloop-0.16.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a19828c4f15687675ea912cc28bbcb48e9bb907c801873bd1519b96b04fb805"},
+    {file = "uvloop-0.16.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e814ac2c6f9daf4c36eb8e85266859f42174a4ff0d71b99405ed559257750382"},
+    {file = "uvloop-0.16.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bd8f42ea1ea8f4e84d265769089964ddda95eb2bb38b5cbe26712b0616c3edee"},
+    {file = "uvloop-0.16.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:647e481940379eebd314c00440314c81ea547aa636056f554d491e40503c8464"},
+    {file = "uvloop-0.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e0d26fa5875d43ddbb0d9d79a447d2ace4180d9e3239788208527c4784f7cab"},
+    {file = "uvloop-0.16.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6ccd57ae8db17d677e9e06192e9c9ec4bd2066b77790f9aa7dede2cc4008ee8f"},
+    {file = "uvloop-0.16.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:089b4834fd299d82d83a25e3335372f12117a7d38525217c2258e9b9f4578897"},
+    {file = "uvloop-0.16.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98d117332cc9e5ea8dfdc2b28b0a23f60370d02e1395f88f40d1effd2cb86c4f"},
+    {file = "uvloop-0.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e5f2e2ff51aefe6c19ee98af12b4ae61f5be456cd24396953244a30880ad861"},
+    {file = "uvloop-0.16.0.tar.gz", hash = "sha256:f74bc20c7b67d1c27c72601c78cf95be99d5c2cdd4514502b4f3eb0933ff1228"},
 ]
 win32-setctime = [
     {file = "win32_setctime-1.0.3-py3-none-any.whl", hash = "sha256:dc925662de0a6eb987f0b01f599c01a8236cb8c62831c22d9cada09ad958243e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/opsani/servo-appdynamics"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-servox = "^0.10.6"
+servox = "^0.10.7"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/opsani/servo-appdynamics"
 [tool.poetry.dependencies]
 python = "^3.8"
 servox = "^0.10.7"
+# note: keep servox version equal to the one in Dockerfile
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"

--- a/servo_appdynamics.py
+++ b/servo_appdynamics.py
@@ -282,7 +282,7 @@ class AppdynamicsConnector(servo.BaseConnector):
         )
 
     @servo.on_event()
-    def describe(self) -> servo.Description:
+    def describe(self, **kwargs) -> servo.Description:
         """Describes the current state of Metrics measured by querying AppDynamics.
 
         Returns:

--- a/servo_appdynamics.py
+++ b/servo_appdynamics.py
@@ -282,7 +282,7 @@ class AppdynamicsConnector(servo.BaseConnector):
         )
 
     @servo.on_event()
-    def describe(self, **kwargs) -> servo.Description:
+    def describe(self, control: servo.Control = servo.Control()) -> servo.Description:
         """Describes the current state of Metrics measured by querying AppDynamics.
 
         Returns:


### PR DESCRIPTION
Linear task: https://linear.app/opsani/issue/ENG-289/update-signatures-of-externally-maintained-connectors-to-prevent

Servox was changed to add 'control' arg to the describe event. This
commit modifies the appdynamis connector to support both the old and the
new variant, by adding **kwargs.

To be followed up by changing '**kwargs' to 'control: servo.Control =...'
for exact match with the new signature.